### PR TITLE
#2706: Allow empty  when filtering metadata

### DIFF
--- a/src/main/java/no/ndla/taxnomy/metadataapi/data/repository/CustomFieldValueRepository.java
+++ b/src/main/java/no/ndla/taxnomy/metadataapi/data/repository/CustomFieldValueRepository.java
@@ -16,4 +16,7 @@ public interface CustomFieldValueRepository extends JpaRepository<CustomFieldVal
 
     @Query("SELECT obj FROM CustomFieldValue obj LEFT JOIN FETCH obj.taxonomyEntity WHERE obj.customField.id = :customField AND obj.value = :value")
     Iterable<CustomFieldValue> findAllByCustomFieldAndValue(UUID customField, String value);
+
+    @Query("SELECT obj FROM CustomFieldValue obj LEFT JOIN FETCH obj.taxonomyEntity WHERE obj.customField.id = :customField")
+    Iterable<CustomFieldValue> findAllByCustomField(UUID customField);
 }

--- a/src/main/java/no/ndla/taxnomy/metadataapi/rest/MetadataController.java
+++ b/src/main/java/no/ndla/taxnomy/metadataapi/rest/MetadataController.java
@@ -38,7 +38,7 @@ public class MetadataController {
 
         final Set<String> publicIdSet;
         if (publicIds == null) {
-            if (key == null || value == null) {
+            if (key == null && value == null) {
                 throw new InvalidRequestException("Query publicIds and key/value not specified");
             }
             publicIdSet = customFieldService.getTaxonomyEntitiesByCustomFieldKeyValue(key, value).stream()

--- a/src/main/java/no/ndla/taxnomy/metadataapi/service/CustomFieldServiceImpl.java
+++ b/src/main/java/no/ndla/taxnomy/metadataapi/service/CustomFieldServiceImpl.java
@@ -70,7 +70,12 @@ public class CustomFieldServiceImpl implements CustomFieldService {
             }
             customFieldId = customField.getId();
         }
-        return StreamSupport.stream(customFieldValueRepository.findAllByCustomFieldAndValue(customFieldId, value).spliterator(), false)
+
+        Iterable<CustomFieldValue> customFields;
+        if (value != null) customFields = customFieldValueRepository.findAllByCustomFieldAndValue(customFieldId, value);
+        else customFields = customFieldValueRepository.findAllByCustomField(customFieldId);
+
+        return StreamSupport.stream(customFields.spliterator(), false)
                 .map(CustomFieldValue::getTaxonomyEntity)
                 .collect(Collectors.toList());
     }

--- a/src/test/java/no/ndla/taxnomy/metadataapi/service/CustomFieldServiceImplTest.java
+++ b/src/test/java/no/ndla/taxnomy/metadataapi/service/CustomFieldServiceImplTest.java
@@ -15,6 +15,8 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 
@@ -112,7 +114,9 @@ public class CustomFieldServiceImplTest {
     @Test
     public void testDeleteUnknownValue() {
         final var id = UUID.randomUUID();
-        assertThrows(EntityNotFoundException.class, () -> {customFieldService.unsetCustomField(id); });
+        assertThrows(EntityNotFoundException.class, () -> {
+            customFieldService.unsetCustomField(id);
+        });
     }
 
     @Test
@@ -157,5 +161,28 @@ public class CustomFieldServiceImplTest {
             assertFalse(iterator.hasNext());
         }
         assertEquals("urn:test:1", taxonomyEntity.getPublicId().toString());
+    }
+
+    @Test
+    public void testGetByKeyNullValue() {
+        {
+            CustomField customField = new CustomField();
+            customField.setPublicId("urn:customfield:1");
+            customField.setKey("testkey");
+            customField = customFieldRepository.save(customField);
+            TaxonomyEntity taxonomyEntity = new TaxonomyEntity();
+            taxonomyEntity.setPublicId("urn:test:1");
+            taxonomyEntity = taxonomyEntityRepository.save(taxonomyEntity);
+            {
+                CustomFieldValue customFieldValue = new CustomFieldValue();
+                customFieldValue.setCustomField(customField);
+                customFieldValue.setTaxonomyEntity(taxonomyEntity);
+                customFieldValue.setValue("testvalue");
+                customFieldValueRepository.save(customFieldValue);
+            }
+        }
+        final var entities = customFieldService.getTaxonomyEntitiesByCustomFieldKeyValue("testkey", null);
+        assertEquals(1, entities.size());
+        assertEquals("urn:test:1", entities.get(0).getPublicId());
     }
 }


### PR DESCRIPTION
NDLANO/Issues#2706

For at metadata-filtrering på kun key skal fungere.

Kan testes med å kjøre en request mot lokalt api filtrer:
`/v1/taxonomy_entities/?key=forklaringsfag`